### PR TITLE
Generalized training loop, fixed ViT model

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 import torch.utils.data
 from torch.utils.data.dataloader import DataLoader
 from dataloaders.clotho_dataloader import AudioCaptioningDataset
-from models.clip import BaseClip 
+from models.clip import BaseClip, ViTClip, PANNClip
 from transformers import ViTFeatureExtractor, ViTModel
 import torch.optim 
 from tensorboard_logger import configure, log_value
@@ -12,21 +12,7 @@ from tensorboard_logger import configure, log_value
 parser = argparse.ArgumentParser(description="Music caption retrieval project for Georgia Tech CS7643")
 parser.add_argument("--config", default="/home/nikhilrk/MusicCaptioning/MusicCaptioning/configs/resnet.yaml")
 
-def run_vision_transformer():
-    """
-    Make predictions on the dataset using a Vision Transformer model on Mel-Spectrogram image representations
-    of input audio.
-
-    See the original paper here:
-    https://arxiv.org/pdf/2010.11929.pdf
-
-    The implementation used comes from the HuggingFace transformers library and does not include a classification
-    head by default. See their documentation here:
-    https://huggingface.co/docs/transformers/model_doc/vit#vision-transformer-vit
-    """
-    return
-
-def run_resnet():
+def train_encoders():
     """
     Make predictions on the dataset using a ResNet-50 model on Mel-Spectrogram image representations
     of input audio.
@@ -39,9 +25,15 @@ def run_resnet():
     https://stackoverflow.com/questions/52796121/how-to-get-the-output-from-a-specific-layer-from-a-pytorch-model)
 
     """
-
-
-    model = BaseClip(temp=1)
+    model = None
+    if args.model == "ViT":
+        model = ViTClip()
+    if args.model == "ResNet":
+        model = BaseClip(temp=1)
+    if args.model == "PANN":
+        model = PANNClip()
+    else:
+        raise NotImplementedError
    
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
@@ -121,19 +113,6 @@ def run_resnet():
 
     return
 
-def run_pann():
-    """
-    Make predictions on the dataset using a Pretrained Audio Neural Network
-    (a CNN pretrained for audio classification using spectrogram images)
-
-    See the original paper here:
-    https://arxiv.org/pdf/1912.10211.pdf
-
-    And GitHub repo here:
-    https://github.com/qiuqiangkong/audioset_tagging_cnn
-    """
-    return
-
 def main():
     # Use a config file to make sure we perform the correct experimental setup
     global args
@@ -149,12 +128,7 @@ def main():
     # Get the dataset
 
     # Make predictions using the appropriate method for the selected model
-    if args.model == "ViT":
-        run_vision_transformer()
-    if args.model == "ResNet":
-        run_resnet()
-    if args.model == "Wavegram_Logmel_Cnn14":
-        run_pann()
+    train_encoders()
         
 
 if __name__ == "__main__":

--- a/models/audio_encoders.py
+++ b/models/audio_encoders.py
@@ -36,6 +36,35 @@ def get_audio_feature_vector(model: nn.Module, img_tensors: torch.Tensor, layer_
     features = torch.reshape(features, (features.size()[0], features.size()[1]))
     return features
 
+def get_vit_feature_vector(model: nn.Module, img_tensors: torch.Tensor, layer_dict={"encoder.layers.encoder_layer_11.mlp":"features"}):
+    """
+    Get feature vectors for the given audio (passed in as a spectrogram image) by returning the output
+    of the selected model at an intermediate layer.
+
+    For more info on create_feature_extractor, see the Torchvision documentation here:
+    http://pytorch.org/vision/main/generated/torchvision.models.feature_extraction.create_feature_extractor.html
+
+    Arguments
+    -----
+    model - A PyTorch nn.Module object
+    img_tensor - A batch of images stored as PyTorch tensors with dimensions (n, c, h, w)
+    layer_dict - A dictionary containing information about the desired intermediate layer output
+        Ex. {'avgpool': 'features'} to obtain the weights at ResNet's avgpool layer stored with the key "features"
+
+    Outputs
+    -----
+    feat_vec - A list of feature vectors for each of the requested layers as tuples in [("name", tensor)] format
+
+    """
+    features = []
+    model = create_feature_extractor(model, layer_dict)
+    img_tensors = img_tensors.unsqueeze(0)
+    model = model.double()
+    out = model(img_tensors)
+    features = out["features"]
+    features = features[:, 0, :]
+    return features
+
 # Pretrained Audio Neural Networks
 def init_layer(layer):
     """Initialize a Linear or Convolutional layer. """


### PR DESCRIPTION
There are some improvements I plan on making to both the current working models (ResNet and ViT) to help them run faster:
1. Adding transforms inside of the models to stack images into 3 channels
2. Replace the list at the beginning of each forward loop and torch.stack with an empty tensor that gets filled in during each batch (need to know the batch size to implement this)
3. Test the full training loop for ViT